### PR TITLE
disable compilation warnings in order to compile with recent GCC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if kernel >= '4.1.0':
 else:
     kernel41 = None
 
-CFLAGS = ['-Wall', '-Werror', '-Wextra', '-Wno-missing-field-initializers' ]
+CFLAGS = ['-Wall', '-Werror', '-Wextra', '-Wno-missing-field-initializers', '-Wno-cast-function-type', '-Wno-format-truncation' ]
 
 classifiers = ['Development Status :: 3 - Alpha',
                'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
In order to compile successfully with GCC 8.3.0 it was necessary to add '-Wno-cast-function-type' and '-Wno-format-truncation' to CFLAGS in setup.py
Please check for runtime failures